### PR TITLE
implement signature help UI when there are multiple signatures

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6967,11 +6967,18 @@ async fn test_handle_input_for_show_signature_help_auto_signature_help_true(
         .await;
 
     cx.editor(|editor, _| {
-        let signature_help_state = editor.signature_help_state.popover().cloned();
-        assert!(signature_help_state.is_some());
+        let signature_help_popover = editor.signature_help_state.popover().cloned();
+        assert!(signature_help_popover.is_some());
+        let signature_help_popover = signature_help_popover.unwrap();
+        let current_page = signature_help_popover.current_page();
+        let signature_help_markdown = signature_help_popover
+            .signature_help_markdowns()
+            .get(current_page);
+        assert!(signature_help_markdown.is_some());
+        let signature_help_markdown = signature_help_markdown.unwrap().clone();
         let ParsedMarkdown {
             text, highlights, ..
-        } = signature_help_state.unwrap().parsed_content;
+        } = signature_help_markdown.signature;
         assert_eq!(text, "param1: u8, param2: u8");
         assert_eq!(highlights, vec![(0..10, SIGNATURE_HELP_HIGHLIGHT_CURRENT)]);
     });
@@ -7139,11 +7146,18 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut gpui:
     cx.condition(|editor, _| editor.signature_help_state.is_shown())
         .await;
     cx.update_editor(|editor, _| {
-        let signature_help_state = editor.signature_help_state.popover().cloned();
-        assert!(signature_help_state.is_some());
+        let signature_help_popover = editor.signature_help_state.popover().cloned();
+        assert!(signature_help_popover.is_some());
+        let signature_help_popover = signature_help_popover.unwrap();
+        let current_page = signature_help_popover.current_page();
+        let signature_help_markdown = signature_help_popover
+            .signature_help_markdowns()
+            .get(current_page);
+        assert!(signature_help_markdown.is_some());
+        let signature_help_markdown = signature_help_markdown.unwrap().clone();
         let ParsedMarkdown {
             text, highlights, ..
-        } = signature_help_state.unwrap().parsed_content;
+        } = signature_help_markdown.signature;
         assert_eq!(text, "param1: u8, param2: u8");
         assert_eq!(highlights, vec![(0..10, SIGNATURE_HELP_HIGHLIGHT_CURRENT)]);
         editor.signature_help_state = SignatureHelpState::default();
@@ -7181,11 +7195,18 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut gpui:
     cx.condition(|editor, _| editor.signature_help_state.is_shown())
         .await;
     cx.editor(|editor, _| {
-        let signature_help_state = editor.signature_help_state.popover().cloned();
-        assert!(signature_help_state.is_some());
+        let signature_help_popover = editor.signature_help_state.popover().cloned();
+        assert!(signature_help_popover.is_some());
+        let signature_help_popover = signature_help_popover.unwrap();
+        let current_page = signature_help_popover.current_page();
+        let signature_help_markdown = signature_help_popover
+            .signature_help_markdowns()
+            .get(current_page);
+        assert!(signature_help_markdown.is_some());
+        let signature_help_markdown = signature_help_markdown.unwrap().clone();
         let ParsedMarkdown {
             text, highlights, ..
-        } = signature_help_state.unwrap().parsed_content;
+        } = signature_help_markdown.signature;
         assert_eq!(text, "param1: u8, param2: u8");
         assert_eq!(highlights, vec![(0..10, SIGNATURE_HELP_HIGHLIGHT_CURRENT)]);
     });
@@ -7243,11 +7264,18 @@ async fn test_signature_help(cx: &mut gpui::TestAppContext) {
         .await;
 
     cx.editor(|editor, _| {
-        let signature_help_state = editor.signature_help_state.popover().cloned();
-        assert!(signature_help_state.is_some());
+        let signature_help_popover = editor.signature_help_state.popover().cloned();
+        assert!(signature_help_popover.is_some());
+        let signature_help_popover = signature_help_popover.unwrap();
+        let current_page = signature_help_popover.current_page();
+        let signature_help_markdown = signature_help_popover
+            .signature_help_markdowns()
+            .get(current_page);
+        assert!(signature_help_markdown.is_some());
+        let signature_help_markdown = signature_help_markdown.unwrap().clone();
         let ParsedMarkdown {
             text, highlights, ..
-        } = signature_help_state.unwrap().parsed_content;
+        } = signature_help_markdown.signature;
         assert_eq!(text, "param1: u8, param2: u8");
         assert_eq!(highlights, vec![(0..10, SIGNATURE_HELP_HIGHLIGHT_CURRENT)]);
     });

--- a/crates/editor/src/signature_help/popover.rs
+++ b/crates/editor/src/signature_help/popover.rs
@@ -1,26 +1,64 @@
 use crate::{Editor, EditorStyle};
 use gpui::{
-    div, AnyElement, InteractiveElement, IntoElement, MouseButton, ParentElement, Pixels, Size,
-    StatefulInteractiveElement, Styled, ViewContext, WeakView,
+    div, AnyElement, InteractiveElement, IntoElement, ParentElement, Pixels, Size, Styled,
+    ViewContext, WeakView,
 };
 use language::ParsedMarkdown;
-use ui::StyledExt;
+use std::cell::RefCell;
+use std::rc::Rc;
+use ui::{Button, ButtonCommon, ButtonSize, Clickable, Disableable, Label, StyledExt};
 use workspace::Workspace;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct SignatureHelpPopover {
-    pub parsed_content: ParsedMarkdown,
+    signature_help_markdowns: Vec<SignatureHelpMarkdown>,
+    current_page: Rc<RefCell<usize>>,
 }
 
-impl PartialEq for SignatureHelpPopover {
+#[derive(Clone, Debug)]
+pub struct SignatureHelpMarkdown {
+    pub signature: ParsedMarkdown,
+    pub signature_description: Option<ParsedMarkdown>,
+}
+
+impl PartialEq for SignatureHelpMarkdown {
     fn eq(&self, other: &Self) -> bool {
-        let str_equality = self.parsed_content.text.as_str() == other.parsed_content.text.as_str();
-        let highlight_equality = self.parsed_content.highlights == other.parsed_content.highlights;
-        str_equality && highlight_equality
+        let signature_str_equality = self.signature.text.as_str() == other.signature.text.as_str();
+        let signature_highlight_equality = self.signature.highlights == other.signature.highlights;
+
+        let signature_description_str_equality = match (
+            self.signature_description.as_ref(),
+            other.signature_description.as_ref(),
+        ) {
+            (Some(text), Some(other_text)) => text.text.as_str() == other_text.text.as_str(),
+            (None, None) => true,
+            _ => false,
+        };
+        signature_str_equality && signature_highlight_equality && signature_description_str_equality
     }
 }
 
 impl SignatureHelpPopover {
+    pub fn new(
+        signature_help_markdowns: Vec<SignatureHelpMarkdown>,
+        active_signature: usize,
+    ) -> Self {
+        Self {
+            signature_help_markdowns,
+            current_page: Rc::new(RefCell::new(active_signature)),
+        }
+    }
+
+    fn has_next_page(&self) -> bool {
+        let current_page = *self.current_page.borrow();
+        current_page + 1 < self.signature_help_markdowns.len()
+    }
+
+    fn has_previous_page(&self) -> bool {
+        let current_page = *self.current_page.borrow();
+        current_page > 0
+    }
+
     pub fn render(
         &mut self,
         style: &EditorStyle,
@@ -28,21 +66,115 @@ impl SignatureHelpPopover {
         workspace: Option<WeakView<Workspace>>,
         cx: &mut ViewContext<Editor>,
     ) -> AnyElement {
-        div()
+        let Some(SignatureHelpMarkdown {
+            signature,
+            signature_description,
+        }) = self
+            .signature_help_markdowns
+            .get(*self.current_page.borrow())
+        else {
+            return div().into_any_element();
+        };
+
+        let signature_element = div()
             .id("signature_help_popover")
-            .elevation_2(cx)
-            .overflow_y_scroll()
             .max_w(max_size.width)
-            .max_h(max_size.height)
-            .on_mouse_move(|_, cx| cx.stop_propagation())
-            .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
             .child(div().p_2().child(crate::render_parsed_markdown(
                 "signature_help_popover_content",
-                &self.parsed_content,
+                signature,
                 style,
-                workspace,
+                workspace.clone(),
                 cx,
             )))
-            .into_any_element()
+            .into_any_element();
+        let boarder = div().border_primary(cx).border_1().into_any_element();
+
+        let signature_help_children = if let Some(signature_description) = signature_description {
+            let signature_description_element = div()
+                .id("signature_help_popover_description")
+                .child(div().p_2().child(crate::render_parsed_markdown(
+                    "signature_help_popover_description_content",
+                    signature_description,
+                    style,
+                    workspace.clone(),
+                    cx,
+                )))
+                .into_any_element();
+            vec![signature_element, boarder, signature_description_element]
+        } else {
+            vec![signature_element]
+        };
+        let signature_help = div()
+            .flex()
+            .flex_col()
+            .children(signature_help_children)
+            .into_any_element();
+
+        if self.signature_help_markdowns.len() > 1 {
+            let previous_button = div().flex().flex_row().justify_center().child({
+                let current_page = self.current_page.clone();
+                Button::new("popover_page_button_previous", "↑")
+                    .size(ButtonSize::Compact)
+                    .disabled(!self.has_previous_page())
+                    .on_click(move |_, _| {
+                        *current_page.borrow_mut() -= 1;
+                    })
+                    .into_any_element()
+            });
+
+            let page = div()
+                .flex()
+                .flex_row()
+                .justify_center()
+                .child(Label::new(format!(
+                    "{} / {}",
+                    *self.current_page.borrow() + 1,
+                    self.signature_help_markdowns.len()
+                )));
+
+            let next_button = div().flex().flex_row().justify_center().child({
+                let current_page = self.current_page.clone();
+                Button::new("popover_page_button_next", "↓")
+                    .size(ButtonSize::Compact)
+                    .disabled(!self.has_next_page())
+                    .on_click(move |_, _| {
+                        *current_page.borrow_mut() += 1;
+                    })
+                    .into_any_element()
+            });
+            let buttons = div()
+                .flex()
+                .child(div().p_1().flex().flex_col_reverse().children([
+                    next_button,
+                    page,
+                    previous_button,
+                ]))
+                .into_any_element();
+
+            let boarder = div().border_primary(cx).border_1().into_any_element();
+
+            div()
+                .elevation_2(cx)
+                .flex()
+                .flex_row()
+                .children([buttons, boarder, signature_help])
+                .into_any_element()
+        } else {
+            div()
+                .elevation_2(cx)
+                .child(signature_help)
+                .into_any_element()
+        }
+    }
+}
+
+#[cfg(test)]
+impl SignatureHelpPopover {
+    pub fn signature_help_markdowns(&self) -> &[SignatureHelpMarkdown] {
+        &self.signature_help_markdowns
+    }
+
+    pub fn current_page(&self) -> usize {
+        *self.current_page.borrow()
     }
 }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -27,9 +27,7 @@ use signature_help::{lsp_to_proto_signature, proto_to_lsp_signature};
 use std::{cmp::Reverse, ops::Range, path::Path, sync::Arc};
 use text::{BufferId, LineEnding};
 
-pub use signature_help::{
-    SignatureHelp, SIGNATURE_HELP_HIGHLIGHT_CURRENT, SIGNATURE_HELP_HIGHLIGHT_OVERLOAD,
-};
+pub use signature_help::{SignatureHelp, SignatureHelps, SIGNATURE_HELP_HIGHLIGHT_CURRENT};
 
 pub fn lsp_formatting_options(tab_size: u32) -> lsp::FormattingOptions {
     lsp::FormattingOptions {
@@ -1242,7 +1240,7 @@ impl LspCommand for GetDocumentHighlights {
 
 #[async_trait(?Send)]
 impl LspCommand for GetSignatureHelp {
-    type Response = Option<SignatureHelp>;
+    type Response = Option<SignatureHelps>;
     type LspRequest = lsp::SignatureHelpRequest;
     type ProtoRequest = proto::GetSignatureHelp;
 
@@ -1283,7 +1281,7 @@ impl LspCommand for GetSignatureHelp {
         mut cx: AsyncAppContext,
     ) -> Result<Self::Response> {
         let language = buffer.update(&mut cx, |buffer, _| buffer.language().cloned())?;
-        Ok(message.and_then(|message| SignatureHelp::new(message, language)))
+        Ok(message.and_then(|message| SignatureHelps::new(message, language)))
     }
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> Self::ProtoRequest {
@@ -1342,7 +1340,7 @@ impl LspCommand for GetSignatureHelp {
         Ok(response
             .signature_help
             .map(|proto_help| proto_to_lsp_signature(proto_help))
-            .and_then(|lsp_help| SignatureHelp::new(lsp_help, language)))
+            .and_then(|lsp_help| SignatureHelps::new(lsp_help, language)))
     }
 
     fn buffer_id_from_proto(message: &Self::ProtoRequest) -> Result<BufferId> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5444,7 +5444,7 @@ impl Project {
         buffer: &Model<Buffer>,
         position: T,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Vec<SignatureHelp>> {
+    ) -> Task<Vec<SignatureHelps>> {
         let position = position.to_point_utf16(buffer.read(cx));
         if self.is_local() {
             let all_actions_task = self.request_multiple_lsp_locally(
@@ -5459,7 +5459,6 @@ impl Project {
                     .await
                     .into_iter()
                     .flatten()
-                    .filter(|help| !help.markdown.is_empty())
                     .collect::<Vec<_>>()
             })
         } else if let Some(project_id) = self.remote_id() {


### PR DESCRIPTION
implement boarder and put center page information

refactoring

use popover_page in signature_help

use boarder

.

.



Release Notes:

- Added/Fixed/Improved ... ([#NNNNN](https://github.com/zed-industries/zed/issues/NNNNN)).

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

### Or...

Release Notes:

- N/A
